### PR TITLE
Fixed Seth's office hour times listed to start at 2:45 instead of 2:35

### DIFF
--- a/docs/02-information/office-hours.md
+++ b/docs/02-information/office-hours.md
@@ -16,7 +16,7 @@ Below are the office hours offered by the course staff for _Spring 2023_. There 
 - **Ashir Imran (Head UCA):** 11 AM - 1 PM, [zoom](https://umass-amherst.zoom.us/j/96338814025)
 - **Xinzhi Liang (TA):**
 - **Liam Neal Reilly (UCA):** 4 PM - 5 PM, CS207-3
-- **Seth Franklin (UCA):** 2:35 PM - 3:45 PM, [zoom](https://umass-amherst.zoom.us/my/seth.franklin)
+- **Seth Franklin (UCA):** 2:45 PM - 3:45 PM, [zoom](https://umass-amherst.zoom.us/my/seth.franklin)
 
 ## Tuesday
 
@@ -31,7 +31,7 @@ Below are the office hours offered by the course staff for _Spring 2023_. There 
 
 - **Harrison Geissler (TA):** 9 AM - 12 PM, CS207
 - **Sridhama Prakhya (TA):** 2 PM - 5 PM, [zoom](https://umass-amherst.zoom.us/my/sridhama)
-- **Seth Franklin (UCA):** 2:35 PM - 3:45 PM, [zoom](https://umass-amherst.zoom.us/my/seth.franklin)
+- **Seth Franklin (UCA):** 2:45 PM - 3:45 PM, [zoom](https://umass-amherst.zoom.us/my/seth.franklin)
 - **Chou Heng Ieong (UCA):** 11 AM - 12 PM, [zoom](https://umass-amherst.zoom.us/j/3352032138)
 
 


### PR DESCRIPTION
My office hours are 2:45-3:45 on Mondays on Wednesdays, but the website lists them as 2:35-3:45. This pull request is to to fix that. Thanks!